### PR TITLE
Remove empty space on tab bar when workspaces button is hidden

### DIFF
--- a/CSS/AutoHide/tabbar.css
+++ b/CSS/AutoHide/tabbar.css
@@ -547,7 +547,7 @@ body:not(:has(.toolbar-editor)) .button-toolbar.newtab {
 }
 
 /* Before toolbar: collapsed state */
-.toolbar.toolbar-tabbar-before.toolbar-large.toolbar-droptarget {
+.toolbar.toolbar-tabbar-before.toolbar-large.toolbar-droptarget:has(> .tabbar-workspace-button) {
   margin: 3px !important;
   min-height: 35px !important;
   max-height: 35px !important;


### PR DESCRIPTION
Just a small change to allow the workspaces button to be hidden. More changes may be necessary, I just wrote up a quick fix for someone else.

In reference to this: https://reddit.com/r/VivaldiCSS/comments/1qv89y5/autohideexpand_on_hover_css_code_help_collapses/