### PR TITLE
Fix extension dropdown menu overflow after Vivaldi update

### DIFF
--- a/Vivaldi7.9Stable/CSS/Extensions.css
+++ b/Vivaldi7.9Stable/CSS/Extensions.css
@@ -44,17 +44,32 @@
   align-items: stretch;
   justify-content: flex-start;
   align-self: flex-start;
+  width: 100%;
+  max-width: var(--popupWidth);
+}
+
+.extensionIconPopupMenu .ExtensionDropdownIcon {
+  width: 100%;
+  max-width: 100%;
+  overflow: hidden;
 }
 
 .extensionIconPopupMenu .ExtensionDropdownIcon > button {
   justify-content: flex-start;
   padding: 10px;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  overflow: hidden;
 }
 
 .extensionIconPopupMenu .ExtensionDropdownIcon > button::after {
   content: attr(title);
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
+  display: block;
+  max-width: 100%;
 }
 
 .button-toolbar > button > .button-badge {


### PR DESCRIPTION
 Summary

  Fixed extension dropdown menu items overflowing beyond the menu boundary after recent Vivaldi version update. The
  clickable area was extending outside the visible menu container, causing visual inconsistency and poor UX.

  Problem

  After updating Vivaldi, the extension dropdown menu displayed incorrectly:
  - Extension name text overflowed beyond the menu boundary
  - Clickable/selectable area extended outside the menu container
  - Long extension names were not properly constrained

  Solution

  Added proper width and overflow constraints to the extension menu components while maintaining the original 280px menu
   width:

  1. Toolbar container: Added max-width: var(--popupWidth) to enforce menu width limit
  2. Extension item container: Added overflow: hidden to .ExtensionDropdownIcon to clip overflowing content
  3. Button elements: Added width: 100%, max-width: 100%, box-sizing: border-box, and overflow: hidden to constrain
  button dimensions
  4. Text content: Enhanced ::after pseudo-element with white-space: nowrap, display: block, and max-width: 100% to
  ensure proper text truncation with ellipsis

  Impact

  - Fixes visual overflow issue
  - Maintains original 280px menu width
  - Improves UX by properly constraining interactive areas
  - No breaking changes to existing functionality