### PR TITLE
fix: correct maxHeight to kebab-case max-height in dialog-content style

### DIFF
--- a/Vivaldi8.0Stable/Javascripts/EasyFiles.js
+++ b/Vivaldi8.0Stable/Javascripts/EasyFiles.js
@@ -339,7 +339,7 @@
         {
           class: "dialog-content",
           style: {
-            maxHeight: "65vh",
+            "max-height": "65vh",
             overflow: "auto",
           },
         },


### PR DESCRIPTION
Fixes #59

The `.dialog-content` style had `maxHeight: "65vh"` but the dialog builder applies styles via `setProperty()` which requires kebab-case not camelCase. So the height constraint was silently never applying, letting the file grid grow unbounded and push the footer out of view with enough files.

The existing `overflow: "auto"` rule had nothing to actually constrain against, so it never triggered scrolling either.

Fix: changed `maxHeight` to `"max-height"` so the constraint applies correctly, restoring the scrollable content area and keeping the footer visible.

Tested with both a small file count (2-3 files, unaffected) and a large file count (12+ files, previously broken, now scrolls correctly with footer visible).