### PR TITLE
feat(installer): add native Linux support, graphical TUI error handling, and process relaunch fixes

### DIFF
--- a/Doc/READMEZH/READMEMAIN.md
+++ b/Doc/READMEZH/READMEMAIN.md
@@ -37,6 +37,12 @@ irm https://raw.githubusercontent.com/PaRr0tBoY/Awesome-Vivaldi/main/install.ps1
 curl -fsSL https://raw.githubusercontent.com/PaRr0tBoY/Awesome-Vivaldi/main/install.sh | bash
 ```
 
+**Linux** (bash):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/PaRr0tBoY/Awesome-Vivaldi/main/install.sh | sudo bash
+```
+
 > 若更倾向手动安装，请参见 **[Installation Guide](./Vivaldi8.0Stable/README.md)**。
 > 如果有一个编程代理，请让它：`Install https://github.com/PaRr0tBoY/Awesome-Vivaldi for me.`
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ irm https://raw.githubusercontent.com/PaRr0tBoY/Awesome-Vivaldi/main/install.ps1
 curl -fsSL https://raw.githubusercontent.com/PaRr0tBoY/Awesome-Vivaldi/main/install.sh | bash
 ```
 
+**Linux** (bash):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/PaRr0tBoY/Awesome-Vivaldi/main/install.sh | sudo bash
+```
+
 To uninstall, run the same script again.
 
 > Prefer manual setup? See the **[Installation Guide](./Vivaldi8.0Stable/README.md)**.

--- a/install.sh
+++ b/install.sh
@@ -727,33 +727,35 @@ find_vivaldi_installations() {
     else
         # Linux discovery
         _add_linux_install() {
-            local app_p="$1"; local res_d="$2"; local disp_n="$3"
-            [ -f "$res_d/window.html" ] || return 0
+            local app_path="$1"; local display_name="$2"
+            local resources_dir="$app_path/resources/vivaldi"
+            [ -f "$resources_dir/window.html" ] || return 0
+
             local version=""
-            if [ -x "$app_p/vivaldi" ]; then
-                version="$("$app_p/vivaldi" --version 2>/dev/null | awk '{print $2}' || true)"
+            if [ -x "$app_path/vivaldi" ]; then
+                version="$("$app_path/vivaldi" --version 2>/dev/null | awk '{print $2}' || true)"
             fi
             if [ -z "$version" ] && command -v vivaldi &>/dev/null; then
                 version="$(vivaldi --version 2>/dev/null | awk '{print $2}' || true)"
             fi
             [ -z "$version" ] && version="unknown"
-            _add_entry "$app_p" "$res_d" "$disp_n" "$version"
+            _add_entry "$app_path" "$resources_dir" "$display_name" "$version"
         }
 
         if [ -n "${VIVALDI_TEST_PATH:-}" ]; then
-            _add_linux_install "$VIVALDI_TEST_PATH" "$VIVALDI_TEST_PATH/resources/vivaldi" "Vivaldi"
+            _add_linux_install "$VIVALDI_TEST_PATH" "Vivaldi"
         else
             local system_paths=(
-                "/opt/vivaldi|/opt/vivaldi/resources/vivaldi|Vivaldi"
-                "/opt/vivaldi-snapshot|/opt/vivaldi-snapshot/resources/vivaldi|Vivaldi Snapshot"
-                "/usr/share/vivaldi|/usr/share/vivaldi/resources/vivaldi|Vivaldi"
-                "/usr/lib/vivaldi|/usr/lib/vivaldi/resources/vivaldi|Vivaldi"
-                "$HOME/.local/share/flatpak/app/com.vivaldi.Vivaldi/current/active/files/extra/opt/vivaldi|$HOME/.local/share/flatpak/app/com.vivaldi.Vivaldi/current/active/files/extra/opt/vivaldi/resources/vivaldi|Vivaldi (Flatpak)"
-                "/var/lib/flatpak/app/com.vivaldi.Vivaldi/current/active/files/extra/opt/vivaldi|/var/lib/flatpak/app/com.vivaldi.Vivaldi/current/active/files/extra/opt/vivaldi/resources/vivaldi|Vivaldi (Flatpak System)"
+                "/opt/vivaldi|Vivaldi"
+                "/opt/vivaldi-snapshot|Vivaldi Snapshot"
+                "/usr/share/vivaldi|Vivaldi"
+                "/usr/lib/vivaldi|Vivaldi"
+                "$HOME/.local/share/flatpak/app/com.vivaldi.Vivaldi/current/active/files/extra/opt/vivaldi|Vivaldi (Flatpak)"
+                "/var/lib/flatpak/app/com.vivaldi.Vivaldi/current/active/files/extra/opt/vivaldi|Vivaldi (Flatpak System)"
             )
             for entry in "${system_paths[@]}"; do
-                IFS='|' read -r app_p res_d disp_n <<< "$entry"
-                [ -d "$res_d" ] && _add_linux_install "$app_p" "$res_d" "$disp_n"
+                IFS='|' read -r app_path display_name <<< "$entry"
+                _add_linux_install "$app_path" "$display_name"
             done
         fi
     fi
@@ -1159,38 +1161,48 @@ post_install() {
     tput cnorm 2>/dev/null || true
     flush_input
     sleep 0.1
-    local vivaldi_running=0
-    if [ "$(uname -s)" = "Darwin" ]; then
-        pgrep -q Vivaldi 2>/dev/null && vivaldi_running=1
-    else
-        pgrep -f "vivaldi" 2>/dev/null && vivaldi_running=1
-    fi
 
-    _launch_linux_vivaldi() {
-        local bin_cmd="vivaldi"
-        if [ -x "$app_path/vivaldi" ]; then
-            bin_cmd="$app_path/vivaldi"
-        elif command -v vivaldi &>/dev/null; then
-            bin_cmd="vivaldi"
-        elif command -v vivaldi-stable &>/dev/null; then
-            bin_cmd="vivaldi-stable"
+    _is_vivaldi_running() {
+        if [ "$(uname -s)" = "Darwin" ]; then
+            pgrep -q Vivaldi 2>/dev/null
+        else
+            pgrep -f "vivaldi" 2>/dev/null
         fi
-        nohup "$bin_cmd" --debug-packed-apps --silent-debugger-extension-api >/dev/null 2>&1 &
     }
 
-    if [ "$vivaldi_running" = "1" ]; then
+    _stop_vivaldi() {
+        if [ "$(uname -s)" = "Darwin" ]; then
+            pkill Vivaldi 2>/dev/null || true
+        else
+            pkill -f "vivaldi" 2>/dev/null || true
+        fi
+        sleep 1
+    }
+
+    _launch_vivaldi() {
+        if [ "$(uname -s)" = "Darwin" ]; then
+            open "$app_path" --args --debug-packed-apps --silent-debugger-extension-api 2>/dev/null || open -a Vivaldi
+        else
+            local bin_cmd="vivaldi"
+            if [ -x "$app_path/vivaldi" ]; then
+                bin_cmd="$app_path/vivaldi"
+            elif command -v vivaldi &>/dev/null; then
+                bin_cmd="vivaldi"
+            elif command -v vivaldi-stable &>/dev/null; then
+                bin_cmd="vivaldi-stable"
+            fi
+            nohup "$bin_cmd" --debug-packed-apps --silent-debugger-extension-api >/dev/null 2>&1 &
+        fi
+    }
+
+    if _is_vivaldi_running; then
         echo ""; echo "$(tr post_vivaldi_running)"; echo ""
         printf "%s " "$(tr post_restart_prompt)"
         local key; key="$(read_key)"
         if [ "$key" = "Y" ] || [ "$key" = "ENTER" ]; then
             echo "Y"; echo ""; echo "  $(tr post_restarting)"
-            if [ "$(uname -s)" = "Darwin" ]; then
-                pkill Vivaldi 2>/dev/null || true; sleep 1
-                open "$app_path" --args --debug-packed-apps --silent-debugger-extension-api 2>/dev/null || open -a Vivaldi
-            else
-                pkill -f "vivaldi" 2>/dev/null || true; sleep 1
-                _launch_linux_vivaldi
-            fi
+            _stop_vivaldi
+            _launch_vivaldi
             echo "  Vivaldi restarted."
         else echo "N"; fi
     else
@@ -1198,11 +1210,7 @@ post_install() {
         local key; key="$(read_key)"
         if [ "$key" = "Y" ] || [ "$key" = "ENTER" ]; then
             echo "Y"
-            if [ "$(uname -s)" = "Darwin" ]; then
-                open "$app_path" --args --debug-packed-apps --silent-debugger-extension-api 2>/dev/null || open -a Vivaldi
-            else
-                _launch_linux_vivaldi
-            fi
+            _launch_vivaldi
             echo "  Vivaldi launched."
         else echo "N"; fi
     fi

--- a/install.sh
+++ b/install.sh
@@ -166,7 +166,7 @@ tr() {
             restore_fresh)            echo "否 — 全新安装" ;;
             restore_copying)          echo "正在从持久化存储恢复模组..." ;;
             restore_done)             echo "已从旧版本恢复 {0} CSS + {1} JS 模组." ;;
-            error_admin_required)     echo "需要管理员权限. 请使用 sudo ./install.sh 重新运行." ;;
+            error_admin_required)     echo "需要管理员权限. 请使用 sudo 重新运行程序:" ;;
             error_download)           echo "错误: 无法下载模组包. 请检查网络连接." ;;
             error_extract)            echo "错误: 无法解压模组包." ;;
             error_no_source)          echo "错误: 找不到模组源文件." ;;
@@ -310,7 +310,7 @@ tr() {
             restore_fresh)            echo "No — start fresh" ;;
             restore_copying)          echo "Restoring mods from persistent storage..." ;;
             restore_done)             echo "Restored {0} CSS + {1} JS mods from previous version." ;;
-            error_admin_required)     echo "Administrator privileges required. Please re-run with: sudo ./install.sh" ;;
+            error_admin_required)     echo "Administrator privileges required. Please re-run using:" ;;
             error_download)           echo "ERROR: Failed to download modpack. Check your internet connection." ;;
             error_extract)            echo "ERROR: Failed to extract modpack archive." ;;
             error_no_source)          echo "ERROR: Could not locate mod source files." ;;
@@ -443,6 +443,44 @@ test_writable() {
         return 0
     fi
     return 1
+}
+
+show_permission_error_frame() {
+    local vivaldi_dir="$1"; local e="$ESC"
+    clear_content
+
+    local inner_w=60
+    _box_row() {
+        local text="$1"; local plain="$2"
+        local pad_len=$(( inner_w - ${#plain} ))
+        [ "$pad_len" -lt 0 ] && pad_len=0
+        local pad; pad="$(printf '%*s' "$pad_len" '')"
+        echo "  ${e}[1;31m│${e}[0m${text}${pad}${e}[1;31m│${e}[0m"
+    }
+
+    local err_title="$(tr error_permission)"
+    local path_label="$(tr target_path)"
+    local admin_msg="$(tr error_admin_required)"
+
+    local sb=""
+    sb+=""$'\n'
+    sb+="  ${e}[1;31m╭────────────────────────────────────────────────────────────╮${e}[0m"$'\n'
+    sb+="$(_box_row "  ${e}[1;31m✖  ${err_title}${e}[0m" "  ✖  ${err_title}")"$'\n'
+    sb+="  ${e}[1;31m├────────────────────────────────────────────────────────────┤${e}[0m"$'\n'
+    sb+="$(_box_row "" "")"$'\n'
+    sb+="$(_box_row "  ${e}[90m${path_label}:${e}[0m ${e}[1;37m${vivaldi_dir}${e}[0m" "  ${path_label}: ${vivaldi_dir}")"$'\n'
+    sb+="$(_box_row "" "")"$'\n'
+    sb+="$(_box_row "  ${e}[33m${admin_msg}${e}[0m" "  ${admin_msg}")"$'\n'
+    sb+="$(_box_row "" "")"$'\n'
+    sb+="$(_box_row "     ${e}[1;36msudo ./install.sh${e}[0m" "     sudo ./install.sh")"$'\n'
+    sb+="$(_box_row "" "")"$'\n'
+    sb+="  ${e}[1;31m╰────────────────────────────────────────────────────────────╯${e}[0m"$'\n\n'
+    sb+="    ${e}[90mENTER confirm | ESC/Q exit${e}[0m"$'\n'
+
+    write_frame "$sb"
+    flush_input
+    read_key > /dev/null
+    FLOW_RESULT="permission_error"
 }
 
 exit_installer() {
@@ -1410,11 +1448,7 @@ install_flow() {
 
     # Permission check before touching Vivaldi's directory
     if ! test_writable "$vivaldi_dir"; then
-        local sb="${e}[1;31m$(tr error_permission)${e}[0m"$'\n'
-        sb+="  $(tr target_path): $vivaldi_dir"$'\n'
-        sb+="${e}[90m$(tr error_admin_required)${e}[0m"$'\n\n'
-        sb+="  ${e}[90m$(tr key_exit)${e}[0m"$'\n'
-        write_frame "$sb"; read_key > /dev/null
+        show_permission_error_frame "$vivaldi_dir"
         return 1
     fi
 
@@ -1531,11 +1565,7 @@ manage_flow() {
 
     # Permission check before touching Vivaldi's directory
     if ! test_writable "$vivaldi_dir"; then
-        local sb="${e}[1;31m$(tr error_permission)${e}[0m"$'\n'
-        sb+="  $(tr target_path): $vivaldi_dir"$'\n'
-        sb+="${e}[90m$(tr error_admin_required)${e}[0m"$'\n\n'
-        sb+="  ${e}[90m$(tr key_exit)${e}[0m"$'\n'
-        write_frame "$sb"; read_key > /dev/null
+        show_permission_error_frame "$vivaldi_dir"
         return 1
     fi
 
@@ -1698,11 +1728,7 @@ do_uninstall() {
 
         # Permission check
         if ! test_writable "$vivaldi_dir"; then
-            local sb="${e}[1;31m$(tr error_permission)${e}[0m"$'\n'
-            sb+="  $(tr target_path): $vivaldi_dir"$'\n'
-            sb+="${e}[90m$(tr error_admin_required)${e}[0m"$'\n\n'
-            sb+="  ${e}[90m$(tr key_exit)${e}[0m"$'\n'
-            write_frame "$sb"; read_key > /dev/null
+            show_permission_error_frame "$vivaldi_dir"
             return 1
         fi
 
@@ -1774,9 +1800,11 @@ main() {
             local result=""
             case "$action" in
                 manage) ensure_mod_source || break; manage_flow "$SOURCE_DIR" "$vivaldi_dir" "$app_path"
-                        [ "$FLOW_RESULT" = "back_to_menu" ] && { FLOW_RESULT=""; continue; }; result="done" ;;
+                        [ "$FLOW_RESULT" = "back_to_menu" ] && { FLOW_RESULT=""; continue; }
+                        [ "$FLOW_RESULT" = "permission_error" ] && exit_installer; result="done" ;;
                 update) ensure_mod_source || break; do_update "$SOURCE_DIR" "$vivaldi_dir"; result="done" ;;
                 uninstall) do_uninstall "$vivaldi_dir" "$app_path"
+                    [ "$FLOW_RESULT" = "permission_error" ] && exit_installer
                     # Re-check state after uninstall — may have removed everything
                     is_installed=0; is_installed "$vivaldi_dir" && is_installed=1
                     has_state=0; get_install_state "$vivaldi_dir" 2>/dev/null && has_state=1
@@ -1866,6 +1894,7 @@ main() {
                 ensure_mod_source || break
                 install_flow "$SOURCE_DIR" "$vivaldi_dir" "$app_path" "" ""
                 [ "$FLOW_RESULT" = "back_to_menu" ] && { FLOW_RESULT=""; continue; }
+                [ "$FLOW_RESULT" = "permission_error" ] && exit_installer
                 post_install "$app_path"
             else exit_installer; fi
             break

--- a/install.sh
+++ b/install.sh
@@ -166,7 +166,7 @@ tr() {
             restore_fresh)            echo "否 — 全新安装" ;;
             restore_copying)          echo "正在从持久化存储恢复模组..." ;;
             restore_done)             echo "已从旧版本恢复 {0} CSS + {1} JS 模组." ;;
-            error_admin_required)     echo "需要管理员权限." ;;
+            error_admin_required)     echo "需要管理员权限. 请使用 sudo ./install.sh 重新运行." ;;
             error_download)           echo "错误: 无法下载模组包. 请检查网络连接." ;;
             error_extract)            echo "错误: 无法解压模组包." ;;
             error_no_source)          echo "错误: 找不到模组源文件." ;;
@@ -310,7 +310,7 @@ tr() {
             restore_fresh)            echo "No — start fresh" ;;
             restore_copying)          echo "Restoring mods from persistent storage..." ;;
             restore_done)             echo "Restored {0} CSS + {1} JS mods from previous version." ;;
-            error_admin_required)     echo "Administrator privileges required." ;;
+            error_admin_required)     echo "Administrator privileges required. Please re-run with: sudo ./install.sh" ;;
             error_download)           echo "ERROR: Failed to download modpack. Check your internet connection." ;;
             error_extract)            echo "ERROR: Failed to extract modpack archive." ;;
             error_no_source)          echo "ERROR: Could not locate mod source files." ;;
@@ -648,25 +648,16 @@ ensure_mod_source() {
 }
 
 # ============================================================
-#  6.  Vivaldi Installation Discovery (macOS)
+#  6.  Vivaldi Installation Discovery (macOS / Linux)
 # ============================================================
 
 find_vivaldi_installations() {
     local found=(); local seen=()
 
-    # Shared: add a Vivaldi installation from a Framework path
-    _add_install() {
-        local framework="$1"
-        local resources_dir="${framework}/Resources/vivaldi"
+    _add_entry() {
+        local app_path="$1"; local resources_dir="$2"; local display_name="$3"; local version="$4"
         [ -f "$resources_dir/window.html" ] || return 0
-        local app_path; app_path="${framework%%/Contents/Frameworks/Vivaldi Framework.framework*}"
-        local app_name; app_name="$(basename "$app_path" .app)"
-        local display_name="Vivaldi"
-        case "$app_name" in *Snapshot*|*snapshot*) display_name="Vivaldi Snapshot" ;; esac
-        local version=""
-        [ -f "$app_path/Contents/Info.plist" ] && version="$(plutil -extract CFBundleShortVersionString raw "$app_path/Contents/Info.plist" 2>/dev/null || echo "unknown")"
         local key="${resources_dir}"
-        # bash 3.2 (macOS): ${arr[*]} / ${arr[@]} on empty array + set -u = unbound variable
         local _dup=0
         if [ "${#seen[@]}" -gt 0 ]; then
             for _s in "${seen[@]}"; do [ "$_s" = "$key" ] && { _dup=1; break; }; done
@@ -677,47 +668,96 @@ find_vivaldi_installations() {
         fi
     }
 
-    # 0th: Direct paths (instant O(1) — Vivaldi install paths are predictable)
-    if [ -z "${VIVALDI_TEST_PATH:-}" ]; then
-        local direct_frameworks=(
-            "/Applications/Vivaldi.app/Contents/Frameworks/Vivaldi Framework.framework"
-            "/Applications/Vivaldi Snapshot.app/Contents/Frameworks/Vivaldi Framework.framework"
-            "$HOME/Applications/Vivaldi.app/Contents/Frameworks/Vivaldi Framework.framework"
-            "$HOME/Applications/Vivaldi Snapshot.app/Contents/Frameworks/Vivaldi Framework.framework"
-        )
-        for framework in "${direct_frameworks[@]}"; do
-            [ -d "$framework" ] && _add_install "$framework"
-        done
+    if [ "$(uname -s)" = "Darwin" ]; then
+        # Shared: add a Vivaldi installation from a Framework path
+        _add_install() {
+            local framework="$1"
+            local resources_dir="${framework}/Resources/vivaldi"
+            [ -f "$resources_dir/window.html" ] || return 0
+            local app_path; app_path="${framework%%/Contents/Frameworks/Vivaldi Framework.framework*}"
+            local app_name; app_name="$(basename "$app_path" .app)"
+            local display_name="Vivaldi"
+            case "$app_name" in *Snapshot*|*snapshot*) display_name="Vivaldi Snapshot" ;; esac
+            local version=""
+            [ -f "$app_path/Contents/Info.plist" ] && version="$(plutil -extract CFBundleShortVersionString raw "$app_path/Contents/Info.plist" 2>/dev/null || echo "unknown")"
+            _add_entry "$app_path" "$resources_dir" "$display_name" "$version"
+        }
+
+        # 0th: Direct paths (instant O(1) — Vivaldi install paths are predictable)
+        if [ -z "${VIVALDI_TEST_PATH:-}" ]; then
+            local direct_frameworks=(
+                "/Applications/Vivaldi.app/Contents/Frameworks/Vivaldi Framework.framework"
+                "/Applications/Vivaldi Snapshot.app/Contents/Frameworks/Vivaldi Framework.framework"
+                "$HOME/Applications/Vivaldi.app/Contents/Frameworks/Vivaldi Framework.framework"
+                "$HOME/Applications/Vivaldi Snapshot.app/Contents/Frameworks/Vivaldi Framework.framework"
+            )
+            for framework in "${direct_frameworks[@]}"; do
+                [ -d "$framework" ] && _add_install "$framework"
+            done
+        else
+            # Test mode: inject a synthetic framework path
+            _add_install "$VIVALDI_TEST_PATH/Vivaldi.app/Contents/Frameworks/Vivaldi Framework.framework"
+        fi
+
+        # 1st: mdfind (Spotlight index, ~instant) — supplement for non-standard installs
+        if [ -z "${VIVALDI_TEST_PATH:-}" ]; then
+            while IFS= read -r -d '' framework; do
+                _add_install "$framework"
+            done < <(mdfind "kMDItemFSName == 'Vivaldi Framework.framework'" -0 2>/dev/null || true)
+        fi
+
+        # 2nd: find (filesystem walk) — used when mdfind empty, or in test mode
+        if [ ${#found[@]} -eq 0 ]; then
+            local search_paths=("/Applications" "$HOME/Applications")
+            [ -n "${VIVALDI_TEST_PATH:-}" ] && search_paths=("$VIVALDI_TEST_PATH")
+            while IFS= read -r -d '' framework; do
+                _add_install "$framework"
+            done < <(find "${search_paths[@]}" -type d -name "Vivaldi Framework.framework" -print0 2>/dev/null)
+        fi
+
+        # 3rd: mdfind for window.html (catch non-standard install layouts) — skip in test mode
+        if [ ${#found[@]} -eq 0 ] && [ -z "${VIVALDI_TEST_PATH:-}" ]; then
+            while IFS= read -r html_path; do
+                [[ "$html_path" == *"Vivaldi"* ]] && [[ "$html_path" == *"Resources/vivaldi/window.html" ]] || continue
+                local resources_dir; resources_dir="$(dirname "$html_path")"
+                local framework; framework="$(dirname "$(dirname "$resources_dir")")"
+                _add_install "$framework"
+            done < <(mdfind "kMDItemFSName == 'window.html'" 2>/dev/null || true)
+        fi
     else
-        # Test mode: inject a synthetic framework path
-        _add_install "$VIVALDI_TEST_PATH/Vivaldi.app/Contents/Frameworks/Vivaldi Framework.framework"
+        # Linux discovery
+        _add_linux_install() {
+            local app_p="$1"; local res_d="$2"; local disp_n="$3"
+            [ -f "$res_d/window.html" ] || return 0
+            local version=""
+            if [ -x "$app_p/vivaldi" ]; then
+                version="$("$app_p/vivaldi" --version 2>/dev/null | awk '{print $2}' || true)"
+            fi
+            if [ -z "$version" ] && command -v vivaldi &>/dev/null; then
+                version="$(vivaldi --version 2>/dev/null | awk '{print $2}' || true)"
+            fi
+            [ -z "$version" ] && version="unknown"
+            _add_entry "$app_p" "$res_d" "$disp_n" "$version"
+        }
+
+        if [ -n "${VIVALDI_TEST_PATH:-}" ]; then
+            _add_linux_install "$VIVALDI_TEST_PATH" "$VIVALDI_TEST_PATH/resources/vivaldi" "Vivaldi"
+        else
+            local system_paths=(
+                "/opt/vivaldi|/opt/vivaldi/resources/vivaldi|Vivaldi"
+                "/opt/vivaldi-snapshot|/opt/vivaldi-snapshot/resources/vivaldi|Vivaldi Snapshot"
+                "/usr/share/vivaldi|/usr/share/vivaldi/resources/vivaldi|Vivaldi"
+                "/usr/lib/vivaldi|/usr/lib/vivaldi/resources/vivaldi|Vivaldi"
+                "$HOME/.local/share/flatpak/app/com.vivaldi.Vivaldi/current/active/files/extra/opt/vivaldi|$HOME/.local/share/flatpak/app/com.vivaldi.Vivaldi/current/active/files/extra/opt/vivaldi/resources/vivaldi|Vivaldi (Flatpak)"
+                "/var/lib/flatpak/app/com.vivaldi.Vivaldi/current/active/files/extra/opt/vivaldi|/var/lib/flatpak/app/com.vivaldi.Vivaldi/current/active/files/extra/opt/vivaldi/resources/vivaldi|Vivaldi (Flatpak System)"
+            )
+            for entry in "${system_paths[@]}"; do
+                IFS='|' read -r app_p res_d disp_n <<< "$entry"
+                [ -d "$res_d" ] && _add_linux_install "$app_p" "$res_d" "$disp_n"
+            done
+        fi
     fi
 
-    # 1st: mdfind (Spotlight index, ~instant) — supplement for non-standard installs
-    if [ -z "${VIVALDI_TEST_PATH:-}" ]; then
-        while IFS= read -r -d '' framework; do
-            _add_install "$framework"
-        done < <(mdfind "kMDItemFSName == 'Vivaldi Framework.framework'" -0 2>/dev/null || true)
-    fi
-
-    # 2nd: find (filesystem walk) — used when mdfind empty, or in test mode
-    if [ ${#found[@]} -eq 0 ]; then
-        local search_paths=("/Applications" "$HOME/Applications")
-        [ -n "${VIVALDI_TEST_PATH:-}" ] && search_paths=("$VIVALDI_TEST_PATH")
-        while IFS= read -r -d '' framework; do
-            _add_install "$framework"
-        done < <(find "${search_paths[@]}" -type d -name "Vivaldi Framework.framework" -print0 2>/dev/null)
-    fi
-
-    # 3rd: mdfind for window.html (catch non-standard install layouts) — skip in test mode
-    if [ ${#found[@]} -eq 0 ] && [ -z "${VIVALDI_TEST_PATH:-}" ]; then
-        while IFS= read -r html_path; do
-            [[ "$html_path" == *"Vivaldi"* ]] && [[ "$html_path" == *"Resources/vivaldi/window.html" ]] || continue
-            local resources_dir; resources_dir="$(dirname "$html_path")"
-            local framework; framework="$(dirname "$(dirname "$resources_dir")")"
-            _add_install "$framework"
-        done < <(mdfind "kMDItemFSName == 'window.html'" 2>/dev/null || true)
-    fi
     printf '%s\n' "${found[@]}"
 }
 
@@ -1120,15 +1160,37 @@ post_install() {
     flush_input
     sleep 0.1
     local vivaldi_running=0
-    pgrep -q Vivaldi 2>/dev/null && vivaldi_running=1
+    if [ "$(uname -s)" = "Darwin" ]; then
+        pgrep -q Vivaldi 2>/dev/null && vivaldi_running=1
+    else
+        pgrep -f "vivaldi" 2>/dev/null && vivaldi_running=1
+    fi
+
+    _launch_linux_vivaldi() {
+        local bin_cmd="vivaldi"
+        if [ -x "$app_path/vivaldi" ]; then
+            bin_cmd="$app_path/vivaldi"
+        elif command -v vivaldi &>/dev/null; then
+            bin_cmd="vivaldi"
+        elif command -v vivaldi-stable &>/dev/null; then
+            bin_cmd="vivaldi-stable"
+        fi
+        nohup "$bin_cmd" --debug-packed-apps --silent-debugger-extension-api >/dev/null 2>&1 &
+    }
+
     if [ "$vivaldi_running" = "1" ]; then
         echo ""; echo "$(tr post_vivaldi_running)"; echo ""
         printf "%s " "$(tr post_restart_prompt)"
         local key; key="$(read_key)"
         if [ "$key" = "Y" ] || [ "$key" = "ENTER" ]; then
             echo "Y"; echo ""; echo "  $(tr post_restarting)"
-            pkill Vivaldi 2>/dev/null || true; sleep 1
-            open "$app_path" --args --debug-packed-apps --silent-debugger-extension-api 2>/dev/null || open -a Vivaldi
+            if [ "$(uname -s)" = "Darwin" ]; then
+                pkill Vivaldi 2>/dev/null || true; sleep 1
+                open "$app_path" --args --debug-packed-apps --silent-debugger-extension-api 2>/dev/null || open -a Vivaldi
+            else
+                pkill -f "vivaldi" 2>/dev/null || true; sleep 1
+                _launch_linux_vivaldi
+            fi
             echo "  Vivaldi restarted."
         else echo "N"; fi
     else
@@ -1136,7 +1198,11 @@ post_install() {
         local key; key="$(read_key)"
         if [ "$key" = "Y" ] || [ "$key" = "ENTER" ]; then
             echo "Y"
-            open "$app_path" --args --debug-packed-apps --silent-debugger-extension-api 2>/dev/null || open -a Vivaldi
+            if [ "$(uname -s)" = "Darwin" ]; then
+                open "$app_path" --args --debug-packed-apps --silent-debugger-extension-api 2>/dev/null || open -a Vivaldi
+            else
+                _launch_linux_vivaldi
+            fi
             echo "  Vivaldi launched."
         else echo "N"; fi
     fi

--- a/install.sh
+++ b/install.sh
@@ -54,15 +54,18 @@ trap on_err ERR
 tty_printf() { [ "$HEADLESS" = "1" ] && return 0; { printf "$@" > /dev/tty; } 2>/dev/null || printf "$@"; }
 
 cleanup() {
+    local exit_code=$?
     { [ -c /dev/tty ] && stty echo icanon < /dev/tty; } 2>/dev/null || true
     tput cnorm 2>/dev/null || true
-    if [ "$EXIT_REQUESTED" = "1" ]; then
-        :  # User-requested exit, no FATAL message
-    elif [ "$CRASH_LINE" != "0" ]; then
-        printf "\n[FATAL line %d] %s\n" "$CRASH_LINE" "$CRASH_CMD"
-        tty_printf "\n${ESC}[1;31m[FATAL line %d] %s${ESC}[0m\n" "$CRASH_LINE" "$CRASH_CMD"
-    else
+    if [ "$EXIT_REQUESTED" = "1" ] || [ "$exit_code" -eq 0 ]; then
         tty_printf "${ESC}[%d;0H${ESC}[0J${ESC}[H" "$((BANNER_LINES + 1))"
+    else
+        printf "\n[FATAL line %d] %s (exit code %d)\n" "$CRASH_LINE" "$CRASH_CMD" "$exit_code"
+        tty_printf "\n${ESC}[1;31m[FATAL line %d] %s (exit code %d)${ESC}[0m\n" "$CRASH_LINE" "$CRASH_CMD" "$exit_code"
+        if [ "$HEADLESS" != "1" ] && [ -c /dev/tty ]; then
+            tty_printf "\n  Press any key to exit...\n"
+            read -rsn1 _ < /dev/tty 2>/dev/null || true
+        fi
     fi
     [ -n "$TEMP_DIR" ] && [ -d "$TEMP_DIR" ] && rm -rf "$TEMP_DIR"
     rm -f "$EXIT_FLAG_FILE"
@@ -389,7 +392,7 @@ is_default_off() {
 # ============================================================
 
 show_banner() {
-    clear
+    clear 2>/dev/null || true
     echo ""
     echo "▄████▄ ▄▄   ▄▄ ▄▄▄▄▄  ▄▄▄▄  ▄▄▄  ▄▄   ▄▄ ▄▄▄▄▄   ██  ██ ▄▄ ▄▄ ▄▄  ▄▄▄  ▄▄    ▄▄▄▄  ▄▄"
     echo "██▄▄██ ██ ▄ ██ ██▄▄  ███▄▄ ██▀██ ██▀▄▀██ ██▄▄    ██▄▄██ ██ ██▄██ ██▀██ ██    ██▀██ ██"
@@ -1098,6 +1101,7 @@ backup_window_html() {
     echo "$(tr deploy_backup_done) $bak_path"
     local persistent_dir="${2:-}"
     [ -n "$persistent_dir" ] && mkdir -p "$persistent_dir" && cp "$html_path" "$persistent_dir/window.html.orig" 2>/dev/null || true
+    return 0
 }
 
 verify_window_html() {
@@ -1109,6 +1113,7 @@ verify_window_html() {
     stale=$(( stale - injector ))
     [ "$stale" -gt 0 ] && echo "  ⚠ $stale stale script tag(s) in window.html — run installer again to clean"
     [ "$injector" -eq 0 ] && echo "  ⚠ injectMods.js missing from window.html"
+    return 0
 }
 
 inject_mod_loader() {
@@ -1124,6 +1129,7 @@ inject_mod_loader() {
         echo "$(tr deploy_inject_done)"
     fi
     verify_window_html "$vivaldi_dir"
+    return 0
 }
 
 deploy_mod_files() {
@@ -1301,6 +1307,7 @@ post_install() {
             echo "  Vivaldi launched."
         else echo "N"; fi
     fi
+    return 0
 }
 
 # ============================================================
@@ -1879,15 +1886,7 @@ main() {
             [ -n "$result" ] && break
             [ "$EXIT_REQUESTED" = 1 ] && break
         done
-        if [ "$result" = "uninstalled" ]; then
-            # Full uninstall just completed — restart Vivaldi to pick up restored window.html,
-            # then loop back to show the fresh install menu (Install/Exit only)
-            post_install "$app_path"
-            result=""
-            continue
-        fi
         post_install "$app_path"
-        break
 
     elif [ "$has_persist" = "1" ]; then
         # --- Cross-version restore ---
@@ -1949,7 +1948,11 @@ main() {
             break
         done
     fi
-        break  # Exit top-level loop (fresh install complete or exit)
+
+        # Re-evaluate state after any completed action and loop back to entry menu
+        is_installed=0; is_installed "$vivaldi_dir" && is_installed=1
+        has_state=0; get_install_state "$vivaldi_dir" 2>/dev/null && has_state=1
+        has_persist=0
     done  # End top-level while loop
     echo ""
 }

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,8 @@
 # @version      2026.7.14
 # @author       Ryan (Acid)
 # @website      https://github.com/PaRr0tBoY/Awesome-Vivaldi
-# @usage        curl -fsSL https://raw.githubusercontent.com/PaRr0tBoY/Awesome-Vivaldi/main/install.sh | bash
+# @usage        macOS: curl -fsSL https://raw.githubusercontent.com/PaRr0tBoY/Awesome-Vivaldi/main/install.sh | bash
+# @usage        Linux: curl -fsSL https://raw.githubusercontent.com/PaRr0tBoY/Awesome-Vivaldi/main/install.sh | sudo bash
 # ==/UserScript==
 #
 # Requirements: bash 3.2+, curl, tput, grep, sed

--- a/install.sh
+++ b/install.sh
@@ -410,9 +410,11 @@ write_frame() {
     local row=$((BANNER_LINES + 1))
     local line_count=0
     local buf=""
+    local plain_line
     while IFS= read -r line || [ -n "$line" ]; do
         buf="${buf}${e}[${row};0H${e}[K"
-        if [ ${#line} -ge "$w" ]; then
+        plain_line="$(echo "$line" | sed "s/${e}\\[[0-9;]*m//g")"
+        if [ "${#plain_line}" -ge "$w" ]; then
             buf="${buf}${line:0:$((w - 1))}"
         else
             buf="${buf}${line}"
@@ -445,8 +447,14 @@ test_writable() {
     return 1
 }
 
-show_permission_error_frame() {
-    local vivaldi_dir="$1"; local e="$ESC"
+show_error_frame() {
+    local err_title="$1"
+    local path_label="$2"
+    local path_val="$3"
+    local msg="$4"
+    local action_hint="$5"
+    local flow_result="${6:-error}"
+    local e="$ESC"
     clear_content
 
     local inner_w=60
@@ -458,21 +466,23 @@ show_permission_error_frame() {
         echo "  ${e}[1;31m│${e}[0m${text}${pad}${e}[1;31m│${e}[0m"
     }
 
-    local err_title="$(tr error_permission)"
-    local path_label="$(tr target_path)"
-    local admin_msg="$(tr error_admin_required)"
-
     local sb=""
     sb+=""$'\n'
     sb+="  ${e}[1;31m╭────────────────────────────────────────────────────────────╮${e}[0m"$'\n'
     sb+="$(_box_row "  ${e}[1;31m✖  ${err_title}${e}[0m" "  ✖  ${err_title}")"$'\n'
     sb+="  ${e}[1;31m├────────────────────────────────────────────────────────────┤${e}[0m"$'\n'
-    sb+="$(_box_row "" "")"$'\n'
-    sb+="$(_box_row "  ${e}[90m${path_label}:${e}[0m ${e}[1;37m${vivaldi_dir}${e}[0m" "  ${path_label}: ${vivaldi_dir}")"$'\n'
-    sb+="$(_box_row "" "")"$'\n'
-    sb+="$(_box_row "  ${e}[33m${admin_msg}${e}[0m" "  ${admin_msg}")"$'\n'
-    sb+="$(_box_row "" "")"$'\n'
-    sb+="$(_box_row "     ${e}[1;36msudo ./install.sh${e}[0m" "     sudo ./install.sh")"$'\n'
+    if [ -n "$path_label" ] || [ -n "$path_val" ]; then
+        sb+="$(_box_row "" "")"$'\n'
+        sb+="$(_box_row "  ${e}[90m${path_label}:${e}[0m ${e}[1;37m${path_val}${e}[0m" "  ${path_label}: ${path_val}")"$'\n'
+    fi
+    if [ -n "$msg" ]; then
+        sb+="$(_box_row "" "")"$'\n'
+        sb+="$(_box_row "  ${e}[33m${msg}${e}[0m" "  ${msg}")"$'\n'
+    fi
+    if [ -n "$action_hint" ]; then
+        sb+="$(_box_row "" "")"$'\n'
+        sb+="$(_box_row "     ${e}[1;36m${action_hint}${e}[0m" "     ${action_hint}")"$'\n'
+    fi
     sb+="$(_box_row "" "")"$'\n'
     sb+="  ${e}[1;31m╰────────────────────────────────────────────────────────────╯${e}[0m"$'\n\n'
     sb+="    ${e}[90mENTER confirm | ESC/Q exit${e}[0m"$'\n'
@@ -480,7 +490,18 @@ show_permission_error_frame() {
     write_frame "$sb"
     flush_input
     read_key > /dev/null
-    FLOW_RESULT="permission_error"
+    FLOW_RESULT="$flow_result"
+}
+
+show_permission_error_frame() {
+    local vivaldi_dir="$1"
+    show_error_frame \
+        "$(tr error_permission)" \
+        "$(tr target_path)" \
+        "$vivaldi_dir" \
+        "$(tr error_admin_required)" \
+        "sudo ./install.sh" \
+        "permission_error"
 }
 
 exit_installer() {

--- a/install.sh
+++ b/install.sh
@@ -1235,7 +1235,12 @@ post_install() {
         else
             pkill -f "vivaldi" 2>/dev/null || true
         fi
-        sleep 1
+        local waited=0
+        while _is_vivaldi_running && [ "$waited" -lt 25 ]; do
+            sleep 0.2
+            waited=$((waited + 1))
+        done
+        sleep 0.3
     }
 
     _launch_vivaldi() {
@@ -1250,7 +1255,30 @@ post_install() {
             elif command -v vivaldi-stable &>/dev/null; then
                 bin_cmd="vivaldi-stable"
             fi
-            nohup "$bin_cmd" --debug-packed-apps --silent-debugger-extension-api >/dev/null 2>&1 &
+
+            local is_flatpak=0
+            [[ "$app_path" == *flatpak* ]] && is_flatpak=1
+
+            if [ "$(id -u)" -eq 0 ] && [ -n "${SUDO_USER:-}" ]; then
+                if command -v systemd-run &>/dev/null; then
+                    if [ "$is_flatpak" -eq 1 ]; then
+                        systemd-run --machine="${SUDO_USER}@.host" --user --unit="vivaldi-launch-$$" \
+                            flatpak run com.vivaldi.Vivaldi --debug-packed-apps --silent-debugger-extension-api >/dev/null 2>&1 &
+                    else
+                        systemd-run --machine="${SUDO_USER}@.host" --user --unit="vivaldi-launch-$$" \
+                            "$bin_cmd" --debug-packed-apps --silent-debugger-extension-api >/dev/null 2>&1 &
+                    fi
+                else
+                    echo ""
+                    echo "  Notice: Running elevated. Please restart Vivaldi from your user session."
+                fi
+            else
+                if [ "$is_flatpak" -eq 1 ]; then
+                    nohup flatpak run com.vivaldi.Vivaldi --debug-packed-apps --silent-debugger-extension-api >/dev/null 2>&1 &
+                else
+                    nohup "$bin_cmd" --debug-packed-apps --silent-debugger-extension-api >/dev/null 2>&1 &
+                fi
+            fi
         fi
     }
 


### PR DESCRIPTION
Adds native Linux support to `install.sh` and fixes browser relaunch issues on Linux.

- **Linux support**: Auto-discovers Vivaldi across system paths (`/opt`, `/usr/share`, `/usr/lib`) and Flatpak (user and system installs).
- **Relaunch fix**: Uses `systemd-run --user` to spawn Vivaldi on Linux relaunch, preventing keyring decryption errors caused by environment loss.
- **Error framing**: Renders permission and runtime errors inside a boxed TUI frame matching the rest of the installer.
- **Flow fixes**: Returns to the main menu after post-install actions and exits with correct status codes on failure.

### Testing
- Tested install, update, and uninstall on CachyOS 7.1.6-1 (Arch Linux).
- Verified Vivaldi relaunch without keyring prompts.
- `bash -n install.sh` passed.

### Screenshots
- New reusable Error Frame UI:
<img width="1003" height="541" alt="Screenshot_20260810_181543" src="https://github.com/user-attachments/assets/2c63a582-e3e3-4463-be16-43c7a8529377" />
