### PR TITLE
fix(Diabar): call injectStyles() in init so panel UI layout applies

### DIFF
--- a/Vivaldi8.0Stable/Javascripts/Diabar.js
+++ b/Vivaldi8.0Stable/Javascripts/Diabar.js
@@ -9527,6 +9527,7 @@
   }
 
   waitForBrowser(() => {
+    injectStyles();
     VividAI.loadConfig({ modKey: "askInPage" });
     window.addEventListener('ask-in-page-config-updated', (e) => {
       VividAI.applyConfig(e.detail || {});


### PR DESCRIPTION
## 变更

在 `Vivaldi8.0Stable/Javascripts/Diabar.js` 的 `waitForBrowser()` 回调开头调用 `injectStyles()`。

## 原因

`injectStyles()` 定义了但从未被调用，导致 Ask in Page 面板的关键 CSS（隐藏空白 webview 层、UI flex 布局）从不注入。

## 验证

Vivaldi 8.1.4087.61（macOS）实测，修复后面板布局正常。

对应 issue#74